### PR TITLE
Retrieve and present results

### DIFF
--- a/onto_mcp/resources.py
+++ b/onto_mcp/resources.py
@@ -655,14 +655,31 @@ def search_objects(
     
     for i, obj in enumerate(all_objects[:display_limit], 1):
         if isinstance(obj, dict):
-            uuid = obj.get('uuid', 'N/A')
-            name = obj.get('name', 'N/A')
-            comment = obj.get('comment', '')
+            # Попытаемся извлечь имя объекта из разных возможных ключей
+            name_keys = [
+                'name',
+                'displayName',
+                'entityName',
+                'title',
+            ]
+            name = next((obj.get(k) for k in name_keys if obj.get(k)), None)
+            if not name:
+                # Попробуем взять имя из связанного шаблона
+                meta_entity = obj.get('metaEntity') or obj.get('metaEntityView') or {}
+                name = meta_entity.get('name') or meta_entity.get('displayName') or 'N/A'
+
+            uuid_keys = [
+                'uuid',
+                'id',
+                'entityId',
+            ]
+            uuid = next((obj.get(k) for k in uuid_keys if obj.get(k)), 'N/A')
+            comment = obj.get('comment', '') or obj.get('description', '')
             
             # Get template info if available
-            meta_entity = obj.get('metaEntity', {})
-            template_name = meta_entity.get('name', '') if meta_entity else ''
-            template_id = meta_entity.get('uuid', '') if meta_entity else ''
+            meta_entity = obj.get('metaEntity') or obj.get('metaEntityView') or {}
+            template_name = meta_entity.get('name') or meta_entity.get('displayName') or ''
+            template_id = meta_entity.get('uuid') or meta_entity.get('id') or ''
             
             result_lines.append(f"{i}. **{name}**")
             result_lines.append(f"   UUID: {uuid}")


### PR DESCRIPTION
Improve object data extraction in `search_objects` to correctly display names, UUIDs, and comments.

The previous implementation only looked for specific keys (`name`, `uuid`, `comment`). This PR expands the search to common alternative keys (`displayName`, `entityName`, `id`, `description`, etc.) and nested `metaEntity` fields, ensuring that available data is always displayed instead of "N/A".

---
<a href="https://cursor.com/background-agent?bcId=bc-1f1cb0a1-c62a-4de6-b5b2-2a13690fdfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f1cb0a1-c62a-4de6-b5b2-2a13690fdfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>